### PR TITLE
[Finishes #154506236] Revise CNN arch

### DIFF
--- a/model.py
+++ b/model.py
@@ -39,11 +39,11 @@ def one_conv_layer(input, ranks=2, stride=1, activation=swish, name='', isTraini
     filters = int(ranks*input_features * REDUCTION)
     assert filters > 0
     with tf.variable_scope(name):
-        print(f'{name} input shape:', input.shape)
+#         print(f'{name} input shape:', input.shape)
         conv = tf.layers.dropout(input, rate=0.25, training=isTraining)
         conv = tf.layers.conv2d(conv, filters=filters, kernel_size=kernel_size, strides=strides, padding='valid', activation=activation)
         conv = tf.transpose(conv, [0,1,3,2])
-        print(f'{name} output shape:', conv.shape)
+#         print(f'{name} output shape:', conv.shape)
 
     return conv
 
@@ -65,9 +65,9 @@ def convolution_layers(mainData, activation, isTraining):
         num_vranks = int(conv.shape.dims[-3])
         conv = tf.reshape(conv, [-1, NUM_SUITS, num_vranks, num_features])
 
-        print('Before flattening shape:', conv.shape)
+#         print('Before flattening shape:', conv.shape)
         conv = tf.layers.flatten(conv, 'conv_output')
-        print('Flattened convolution output shape:', conv.shape)
+#         print('Flattened convolution output shape:', conv.shape)
 
     return conv
 

--- a/model.py
+++ b/model.py
@@ -30,22 +30,24 @@ def hidden_layers(input, depth, width, activation):
             input = output
     return output
 
-def one_conv_layer(input, ranks=2, stride=1, activation=swish, name=''):
+def one_conv_layer(input, ranks=2, stride=1, activation=swish, name='', isTraining=True):
     assert input.shape.dims[-1] == 1
     input_features = int(input.shape.dims[-2])
     kernel_size = (ranks, input_features)
     strides = (stride, 1)
-    filters = (ranks*input_features * 4) // 5           # 80% reduction in features
+    REDUCTION = 0.8 # Output layer will have 80% of the features of the input layer.
+    filters = int(ranks*input_features * REDUCTION)
     assert filters > 0
     with tf.variable_scope(name):
-        # print(f'{name} input shape:', input.shape)
-        conv = tf.layers.conv2d(input, filters=filters, kernel_size=kernel_size, strides=strides, padding='valid', activation=activation)
+        print(f'{name} input shape:', input.shape)
+        conv = tf.layers.dropout(input, rate=0.25, training=isTraining)
+        conv = tf.layers.conv2d(conv, filters=filters, kernel_size=kernel_size, strides=strides, padding='valid', activation=activation)
         conv = tf.transpose(conv, [0,1,3,2])
-        # print(f'{name} output shape:', conv.shape)
+        print(f'{name} output shape:', conv.shape)
 
     return conv
 
-def convolution_layers(mainData, activation):
+def convolution_layers(mainData, activation, isTraining):
     with tf.variable_scope('convolution_layers'):
         distribution = extract_distribution(mainData)
 
@@ -53,18 +55,19 @@ def convolution_layers(mainData, activation):
         assert num_features == INPUT_FEATURES
         conv = tf.reshape(distribution, [-1, NUM_RANKS, num_features, 1])
 
-        conv = one_conv_layer(conv, ranks=2, stride=1, name='L1_R2_S1', activation=activation)
-        conv = one_conv_layer(conv, ranks=4, stride=4, name='L2_R4_S4', activation=activation)
-        conv = one_conv_layer(conv, ranks=3, stride=1, name='L3_R3_S1', activation=activation)
+        conv = one_conv_layer(conv, ranks=2, stride=1, name='L1_R2_S1', activation=activation, isTraining=isTraining)
+        conv = one_conv_layer(conv, ranks=4, stride=2, name='L2_R4_S2', activation=activation, isTraining=isTraining)
+        conv = one_conv_layer(conv, ranks=3, stride=2, name='L3_R3_S2', activation=activation, isTraining=isTraining)
+        conv = one_conv_layer(conv, ranks=2, stride=1, name='L4_R2_S1', activation=activation, isTraining=isTraining)
 
         assert conv.shape.dims[-1] == 1
         num_features = int(conv.shape.dims[-2])
         num_vranks = int(conv.shape.dims[-3])
         conv = tf.reshape(conv, [-1, NUM_SUITS, num_vranks, num_features])
 
-        # print('Before flattening shape:', conv.shape)
+        print('Before flattening shape:', conv.shape)
         conv = tf.layers.flatten(conv, 'conv_output')
-        # print('Flattened convolution output shape:', conv.shape)
+        print('Flattened convolution output shape:', conv.shape)
 
     return conv
 
@@ -84,12 +87,14 @@ def activation_fn(name):
 def model_fn(features, labels, mode, params={}):
     """Model function for Estimator."""
 
+    isTraining = mode != tf.estimator.ModeKeys.PREDICT
+
     hidden_width = params['hidden_width']
     hidden_depth = params['hidden_depth']
     activation = activation_fn(params['activation'])
 
     mainData = features[MAIN_DATA]
-    conv_layers = convolution_layers(mainData, activation)
+    conv_layers = convolution_layers(mainData, activation, isTraining)
 
     with tf.variable_scope('legal_plays'):
         # Here we want a pure legal plays vector.

--- a/train.py
+++ b/train.py
@@ -159,8 +159,8 @@ if __name__ == '__main__':
     eval_memmaps = load_memmaps(eval_dir)
 
     evals = {}
-    for hidden_width in [340]:
-        for hidden_depth in [5, 6, 7]:
+    for hidden_width in [160]:
+        for hidden_depth in [2]:
             for activation in ['swish5']:
                 params = {
                     'hidden_depth': hidden_depth,


### PR DESCRIPTION
As stated in the [tracker story](https://www.pivotaltracker.com/story/show/154506236), the CNN architecture now uses 4 layers:

```
in    Height    Stride    out 
13      2          1       12
12      4          2        5
5       3          2        2
2       2          1        1
```
(The code uses "Ranks" instead of "Height").

There are currently 127 features per suit for a total of 428 features in the final layer.

I also added a dropout layer, but have not yet done any experimentation to see how this affects the resulting model.

