### PR TITLE
[Delivers #154507795] Make it possible to run any combination of the three heads

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -40,6 +40,9 @@ number_re = re.compile(r'^(\d+)([KM]?)$')
 default_vals = {
     'DECK_EPOCHS': 100,
     'DECK_BATCH': 64*1024,
+    'DECK_SCORE': 1,
+    'DECK_MOON': 1,
+    'DECK_TRICK': 1,
 }
 
 def env_val(name) :
@@ -60,6 +63,9 @@ def env_val(name) :
 
 BATCH = env_val('DECK_BATCH')
 EPOCHS = env_val('DECK_EPOCHS')
+SCORE = env_val('DECK_SCORE') == 1
+MOON = env_val('DECK_MOON') == 1
+TRICK = env_val('DECK_TRICK') == 1
 
 MAIN_DATA = 'main_data'
 EXPECTED_SCORE = 'expected_score'


### PR DESCRIPTION
The most interesting result of experimentation with this change is that the "Win Trick" loss is badly constrained when it is run with another head. When run by itself, the loss ends up near 5.64e-5. When run with the expected score head, the win trick loss ends up near 2.0e-4. When run with all three heads, historically the best result was 4.0e-3. This latter comparison may not be valid though because there have been other changes since that historical test run.