### PR TITLE
[Delivers# 154509702] Rotate through entire dataset when using small batches

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -40,8 +40,9 @@ number_re = re.compile(r'^(\d+)([KM]?)$')
 # TODO: Add a real command line interface instead of this hack using environment variables
 # https://www.pivotaltracker.com/story/show/154507407
 default_vals = {
-    'DECK_EPOCHS': 100,
-    'DECK_BATCH': 64*1024,
+    'DECK_EPOCHS': 100,   # This is really "EVALS", not "EPOCHS", since we typically evalutate multiple times per epoch
+    'DECK_BATCH': 1*1024, # Batch size should start low, as we will automically double it each true epoch
+    'DECK_STEPS': 64,     # batch steps per evaluation checkpoint
 
     # These three are really booleans. Use 0 for False, 1 for True
     'DECK_SCORE': 1,
@@ -72,6 +73,7 @@ def env_val(name) :
     return val
 
 BATCH = env_val('DECK_BATCH')
+STEPS = env_val('DECK_STEPS')
 EPOCHS = env_val('DECK_EPOCHS')
 SCORE = env_val('DECK_SCORE') == 1
 MOON = env_val('DECK_MOON') == 1
@@ -84,3 +86,6 @@ MAIN_DATA = 'main_data'
 EXPECTED_SCORE = 'expected_score'
 WIN_TRICK_PROB = 'win_trick_prob'
 MOON_PROB = 'moon_prob'
+
+TRAINING = 'training'
+VALIDATION = 'validation'

--- a/model.py
+++ b/model.py
@@ -197,14 +197,14 @@ def model_fn(features, labels, mode, params={}):
 
     eval_metric_ops = {}
 
-    # if SCORE:
-    #   eval_metric_ops['expected_score_loss'] = tf.log(tf.metrics.mean_squared_error(y_expected_score, expectedScoreLogits))
-    #
-    # if TRICK:
-    #   eval_metric_ops['win_trick_prob_loss'] = tf.log(tf.metrics.mean_squared_error(y_win_trick_prob, winTrickLogits))
-    #
-    # if MOON:
-    #   eval_metric_ops['moon_prob_loss'] = tf.log(tf.metrics.mean(moon_prob_loss))
+    if SCORE:
+      eval_metric_ops['expected_score_loss'] = tf.metrics.mean_squared_error(y_expected_score, expectedScoreLogits)
+
+    if TRICK:
+      eval_metric_ops['win_trick_prob_loss'] = tf.metrics.mean_squared_error(y_win_trick_prob, winTrickLogits)
+
+    if MOON:
+      eval_metric_ops['moon_prob_loss'] = tf.metrics.mean(moon_prob_loss)
 
     return tf.estimator.EstimatorSpec(mode=mode, loss=total_loss, train_op=train_op, export_outputs=export_outputs,
                                         eval_metric_ops=eval_metric_ops)

--- a/train.py
+++ b/train.py
@@ -11,8 +11,7 @@ import sys
 import tensorflow as tf
 
 from model import model_fn
-from constants import (MAIN_INPUT_SHAPE, SCORES_SHAPE, WIN_TRICK_PROBS_SHAPE, MOONPROBS_SHAPE, CARDS_IN_DECK
-                    , EPOCHS, BATCH, MAIN_DATA, EXPECTED_SCORE, MOON_PROB, WIN_TRICK_PROB)
+from constants import *
 
 ROOT_MODEL_DIR = './model_dir'
 
@@ -50,19 +49,70 @@ def load_memmaps(dirPath):
     assert len(winTrickProbs) == nsamples
     assert len(moonProbData) == nsamples
 
-    # TODO: Make this a parameter
-    MAX_BATCHES = 40
-    batches = min(MAX_BATCHES, max(nsamples // BATCH, 1))
-    N = min(batches * BATCH, nsamples)
-    print(f'Loaded data from {dirPath}, will do {batches} batches for total of {N} samples')
-    return mainData[:N], scoresData[:N], winTrickProbs[:N], moonProbData[:N]
+    print(f'Loaded {nsamples} samples')
 
-def get_input_fn(memmaps, shuffle=False):
+    return mainData, scoresData, winTrickProbs, moonProbData
+
+
+# We load all training and validation data into (virtual) RAM by using numpy memmap files.
+# We can fairly easily generate plenty of data and still easily fit it all into RAM on a machine with 32Gb of RAM.
+# The amount of data is much larger than a reasonable batch size.
+#
+# We make sequential passes through the data.
+# For training, we instruct estimator.train() to do STEPS steps with batch-size BATCH, and then return
+# so that we can run evaluation. We evaluate (from the validation data) the same total number of samples BATCH*STEPS,
+# but we tell estimator.evaluate() that we're doing 1 step with batch size BATCH*STEPS.
+# We call one iteration of processing BATCH*STEPS samples processed an "evaluation", and the number of samples
+# an "eval_size"
+#
+# At the end of each sequential pass through the data, we increase the batch size. In the usual case we simply
+# double the BATCH size, and leave STEPS unchanged. But eventually this will make the eval_size greater than the
+# number of samples available. We also need to be careful that rounding down doesn't leave us processing only
+# slightly more than half of the available data.
+#
+# The code below to achieve this is a little messy, but works as is. I'm defering making it prettier as I want
+# to move on to other improvements.
+
+def get_input_fn(name, memmaps):
+    global BATCH, STEPS
+
     mainData, scoresData, winTrickProbs, moonProbData = memmaps
 
     iterator_initializer_hook = IteratorInitializerHook()
 
+    nsamples = len(mainData)
+    samples_this_eval = BATCH * STEPS
+    assert samples_this_eval <= nsamples
+
+    evals = nsamples // samples_this_eval
+
+    eval = get_input_fn._eval[name] % evals
+
+    if name == TRAINING and eval == 0:
+        if samples_this_eval*4 < nsamples:
+            # The usual case here. We can double the batch size and leave STEPS alone
+            BATCH = BATCH*2
+        else:
+            # We shouldn't increase BATCH size without changing STEPS, or we'll stop processing up to half the data
+            # This may increase STEPS at first, from say 64 to something less than 128, but it will eventually
+            # reduce to 1.
+            BATCH = BATCH*2
+            STEPS = nsamples // BATCH
+            if STEPS <= 1:
+                STEPS = 1
+                BATCH = nsamples
+        print(f'********** Bumped batch to {BATCH}, steps to {STEPS}  **********')
+        get_input_fn._eval[TRAINING] = 0
+        get_input_fn._eval[VALIDATION] = 0
+
     def input_fn():
+
+        start = get_input_fn._eval[name] * BATCH * STEPS
+        get_input_fn._eval[name] += 1
+
+        batchSize = BATCH if name == TRAINING else BATCH*STEPS
+
+        print(f'*** {name} input_fn() here with batch {batchSize} and start {start} ***')
 
         with tf.variable_scope('input_fn'):
             main_data_placeholder = tf.placeholder(tf.float32, batchShape(MAIN_INPUT_SHAPE), name=MAIN_DATA)
@@ -74,19 +124,23 @@ def get_input_fn(memmaps, shuffle=False):
         iterator_initializer_hook.iterator_initializer_func = \
             lambda sess: sess.run(
                 iterator.initializer,
-                feed_dict={main_data_placeholder: mainData,
-                           scores_data_placeholder: scoresData,
-                           win_trick_data_placeholder: winTrickProbs,
-                           moon_data_placeholder: moonProbData
+                feed_dict={main_data_placeholder: mainData[start:],
+                           scores_data_placeholder: scoresData[start:],
+                           win_trick_data_placeholder: winTrickProbs[start:],
+                           moon_data_placeholder: moonProbData[start:]
                            })
-        dataset = dataset.repeat(1).batch(BATCH)
-        if shuffle:
-            dataset = dataset.shuffle(BATCH*3)
+        dataset = dataset.repeat(1).batch(batchSize)
         iterator = dataset.make_initializable_iterator()
         (main, (scores, win_trick, moon)) = iterator.get_next()
+
         return {MAIN_DATA: main}, {EXPECTED_SCORE: scores, WIN_TRICK_PROB: win_trick, MOON_PROB: moon}
 
     return input_fn, iterator_initializer_hook
+
+get_input_fn._eval = {
+    TRAINING: 0,
+    VALIDATION: 0
+}
 
 def save_checkpoint(estimator, model_dir_path, serving_input_receiver_fn):
     export_dir_base = f'{model_dir_path}/savedmodel'
@@ -116,13 +170,16 @@ def train_with_params(train_memmaps, eval_memmaps, params):
     backsteps = 0
     best_eval_loss = float('inf')
 
-    train_input_fn, train_iterator_initializer_hook = get_input_fn(train_memmaps, shuffle=True)
-    eval_input_fn, eval_iterator_initializer_hook = get_input_fn(eval_memmaps)
+    global BATCH
+    BATCH = BATCH // 2   # this is a hack to make the algorithm to increase BATCH size simpler.
 
-    for batch in range(1, EPOCHS+1):
-        estimator.train(train_input_fn, steps=None, hooks=[train_iterator_initializer_hook])
-        evaluation = estimator.evaluate(eval_input_fn, steps=None, hooks=[eval_iterator_initializer_hook])
-        print(f'{batch}/{EPOCHS}: Evaluation:', evaluation, file=sys.stderr)
+    for epoch in range(0, EPOCHS):
+        train_input_fn, train_iterator_initializer_hook = get_input_fn(TRAINING, train_memmaps)
+        eval_input_fn, eval_iterator_initializer_hook = get_input_fn(VALIDATION, eval_memmaps)
+
+        estimator.train(train_input_fn, steps=STEPS, hooks=[train_iterator_initializer_hook])
+        evaluation = estimator.evaluate(eval_input_fn, steps=1, hooks=[eval_iterator_initializer_hook])
+        print(f'{epoch+1}/{EPOCHS}: Evaluation:', evaluation, file=sys.stderr)
         eval_loss = evaluation['loss']
         if best_eval_loss > eval_loss:
             best_eval_loss = eval_loss
@@ -157,6 +214,11 @@ if __name__ == '__main__':
 
     train_memmaps = load_memmaps(train_dir)
     eval_memmaps = load_memmaps(eval_dir)
+
+    if len(train_memmaps[0]) > len(eval_memmaps[0]):
+        print('Swapping training and eval so that eval is the larger dataset')
+        train_memmaps, eval_memmaps = eval_memmaps, train_memmaps
+    assert len(train_memmaps[0]) <= len(eval_memmaps[0])
 
     evals = {}
     for hidden_width in [160]:


### PR DESCRIPTION
We now make better use of all of the available data by working around the fact that the tf.Estimator framework always reinitializes the input iterators every time we call `Estimator.train()` or `Estimator.evaluate()`. The solution is a bit hacky, but I don't think there is a significantly better solution without changing the Estimator framework.

As a bonus, I also changed things so that we can start with small batch sizes (1K seems to work well) and then automatically increase the batch size after each full epoch (pass across all of the data).

With the roughly 2M samples I currently use (for both training and evaluation), this seems to converge on fully optimized network before 100 iterations of the train loop. These iterations are still called "epochs" by the logging, which is misleading, as at first it takes close to 30 iterations to make one full pass across the data. It makes another complete pass in ~15 iterations, with each subsequent pass taking half the number of iterations. By the time one iteration is a full epoch, any further improvements in loss function are insignificant.