### PR TITLE
[Delivers #155499549] Write numpy files from c to make pipeline more testable and use CNN features only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ add_executable(disttest disttest.cpp)
 add_executable(hearts hearts.cpp)
 add_executable(tournament tournament.cpp)
 add_executable(validate validate.cpp)
+add_executable(numpywriter numpywriter.cpp)
 
 include_directories( ${PROJECT_SOURCE_DIR} dlib )
 
@@ -25,3 +26,4 @@ target_link_libraries(disttest ${ALL_LIBRARIES})
 target_link_libraries(hearts ${ALL_LIBRARIES})
 target_link_libraries(tournament ${ALL_LIBRARIES})
 target_link_libraries(validate ${ALL_LIBRARIES})
+target_link_libraries(numpywriter ${ALL_LIBRARIES})

--- a/analyze.cpp
+++ b/analyze.cpp
@@ -145,8 +145,8 @@ void runGame(StrategyPtr players[4]) {
   if (outcome.shotTheMoon()) {
     printf("Shot the moon!\n");
   }
-  printf("Final scores: %3.1f %3.1f %3.1f %3.1f\n", outcome.modifiedScore(0), outcome.modifiedScore(1)
-            , outcome.modifiedScore(2), outcome.modifiedScore(3));
+  printf("Final scores: %3.1f %3.1f %3.1f %3.1f\n", outcome.standardScore(0), outcome.standardScore(1)
+            , outcome.standardScore(2), outcome.standardScore(3));
 }
 
 int main(int argc, char** argv)

--- a/constants.py
+++ b/constants.py
@@ -7,33 +7,24 @@ NUM_RANKS = 13
 NUM_PLAYERS = 4
 PLAYS_PER_TRICK = 4
 
-MOON_FLAGS_LEN = 4
-POINTS_SO_FAR_LEN = PLAYS_PER_TRICK + 1 + MOON_FLAGS_LEN
-
-# 7 features columns. The probabilities for each of the 4 players,
-# plus 3 more: legal plays, high card in trick, and point value.
+# 10 features columns. The probabilities for each of the 4 players,
+# plus 6 more: legal plays, high card in trick, and point value.
 # Note that legal plays is a vector we must extract in the model.
-# We have been placing it first, but we now make it the 5th column (column index 4),
-# as that makes it easier to optionally set whether we include the two non-point suits (clubs & diamonds)
-# redundantly when we combine the CNN output with the non-CNN features.
-INPUT_FEATURES = NUM_PLAYERS + 3
+# We place it as the first column, for convenience.
+INPUT_FEATURES = 10
 
-EXTRA_FEATURES = 33
-
-TOTAL_SCALAR_FEATURES = CARDS_IN_DECK*INPUT_FEATURES + POINTS_SO_FAR_LEN + EXTRA_FEATURES
+TOTAL_SCALAR_FEATURES = CARDS_IN_DECK*INPUT_FEATURES
 
 DECK_SHAPE = (CARDS_IN_DECK,)
 
-MAIN_INPUT_SHAPE = (TOTAL_SCALAR_FEATURES,)
+MAIN_INPUT_SHAPE = (CARDS_IN_DECK,INPUT_FEATURES)
 
 SUITS_RANKS_SHAPE = (NUM_SUITS, NUM_RANKS)
 
-POINTS_SO_FAR_SHAPE = (POINTS_SO_FAR_LEN,)
-
 SCORES_SHAPE = DECK_SHAPE
 WIN_TRICK_PROBS_SHAPE = DECK_SHAPE
-MOON_CLASSES = 5
-MOONPROBS_SHAPE = (MOON_CLASSES*CARDS_IN_DECK,)
+MOON_CLASSES = 3
+MOONPROBS_SHAPE = (CARDS_IN_DECK, MOON_CLASSES)
 
 number_re = re.compile(r'^(\d+)([KM]?)$')
 

--- a/lib/Annotator.cpp
+++ b/lib/Annotator.cpp
@@ -11,7 +11,7 @@ Annotator::Annotator()
 
 void Annotator::On_DnnMonteCarlo_choosePlay(const KnowableState& state
                                   , PossibilityAnalyzer* analyzer
-                                  , const float expectedScore[13], const float moonProb[13][5])
+                                  , const float expectedScore[13], const float moonProb[13][3])
 {
   assert(false);
 }
@@ -22,7 +22,7 @@ void Annotator::OnGameStateBeforePlay(const GameState& state)
 }
 
 void Annotator::OnWriteData(const KnowableState& state, PossibilityAnalyzer* analyzer, const float expectedScore[13]
-                          , const float moonProb[13][5], const float winsTrickProb[13])
+                          , const float moonProb[13][3], const float winsTrickProb[13])
 {
   assert(false);
 }

--- a/lib/Annotator.h
+++ b/lib/Annotator.h
@@ -18,10 +18,10 @@ public:
   Annotator();
 
   virtual void On_DnnMonteCarlo_choosePlay(const KnowableState& state, PossibilityAnalyzer* analyzer
-                                 , const float expectedScore[13], const float moonProb[13][5]);
+                                 , const float expectedScore[13], const float moonProb[13][3]);
 
   virtual void OnGameStateBeforePlay(const GameState& state);
 
   virtual void OnWriteData(const KnowableState& state, PossibilityAnalyzer* analyzer, const float expectedScore[13]
-  , const float moonProb[13][5], const float winsTrickProb[13]);
+  , const float moonProb[13][3], const float winsTrickProb[13]);
 };

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(lib STATIC
     TwoOpponentsGetSuit.cpp
     VoidBits.cpp
     WriteDataAnnotator.cpp
+    WriteTrainingDataSets.cpp
     combinatorics.cpp
     debug.cpp
     math.cpp

--- a/lib/Card.h
+++ b/lib/Card.h
@@ -38,6 +38,7 @@ const uint8_t kSuitsPerDeck = 4u;
 const uint8_t kCardsPerSuit = 13u;
 const uint8_t kCardsPerHand = 13u;
 const uint8_t kCardsPerDeck = kSuitsPerDeck * kCardsPerSuit;
+const unsigned kNumPlayers = 4u;
 
 inline Suit SuitOf(Card card) { return card / kCardsPerSuit; }
 inline Rank RankOf(Card card) { return card % kCardsPerSuit; }

--- a/lib/DebugStats.h
+++ b/lib/DebugStats.h
@@ -1,0 +1,42 @@
+// lib/DebugStats.h
+
+#pragma once
+
+#include <algorithm>
+#include <stdio.h>
+
+#define DEBUG_STATS 0
+
+class DebugStats
+{
+public:
+  DebugStats(const char* label) : mLabel(label), mSum1(0), mSum2(0), mMin(1.0e6), mMax(-1.0e6), mNum(0) {}
+
+  ~DebugStats() { Print(); }
+
+  void Print() {
+    #if DEBUG_STATS
+    float avg = mSum1 / mNum;
+    float std = sqrt(mSum2/mNum - avg*avg);
+    printf("%s Mean: %4.2f, std: %4.2f, min: %4.2f, max: %4.2f\n", mLabel, avg, std, mMin, mMax);
+    #endif
+  }
+
+  inline void Accum(float x) {
+    #if DEBUG_STATS
+    mSum1 += x;
+    mSum2 += x*x;
+    mMin = std::min(mMin, x);
+    mMax = std::max(mMax, x);
+    mNum += 1;
+    #endif
+  }
+
+private:
+  const char* mLabel;
+  float mSum1;
+  float mSum2;
+  float mMin;
+  float mMax;
+  int   mNum;
+};

--- a/lib/DnnModelIntuition.cpp
+++ b/lib/DnnModelIntuition.cpp
@@ -32,7 +32,13 @@ DnnModelIntuition::DnnModelIntuition(const tensorflow::SavedModelBundle& model, 
 
 Card DnnModelIntuition::choosePlay(const KnowableState& state, const RandomGenerator& rng) const
 {
-  tensorflow::Tensor mainData = state.Transform();
+  FloatMatrix matrix = state.AsFloatMatrix();
+  Tensor mainData(DT_FLOAT, TensorShape({1, kCardsPerDeck, KnowableState::kNumFeaturesPerCard}));
+
+  const float* srcData = matrix.data();
+  float* dstData = mainData.flat<float>().data();
+
+  memcpy(dstData, srcData, kCardsPerDeck*KnowableState::kNumFeaturesPerCard*sizeof(float));
 
   std::vector<tensorflow::Tensor> outputs;
   mPredictor->Predict(mainData, outputs);

--- a/lib/DnnMonteCarloAnnotator.cpp
+++ b/lib/DnnMonteCarloAnnotator.cpp
@@ -15,7 +15,7 @@ DnnMonteCarloAnnotator::DnnMonteCarloAnnotator(const tensorflow::SavedModelBundl
 }
 
 void DnnMonteCarloAnnotator::On_DnnMonteCarlo_choosePlay(const KnowableState& state, PossibilityAnalyzer* analyzer
-                               , const float empiricalExpectedScore[13], const float empiricalMoonProb[13][5])
+                               , const float empiricalExpectedScore[13], const float empiricalMoonProb[13][3])
 {
   const CardHand choices = state.LegalPlays();
   printf("Play %d, Player Leading %d, Current Player %d, Choices %d TrickSuit %s\n"
@@ -57,7 +57,7 @@ void DnnMonteCarloAnnotator::On_DnnMonteCarlo_choosePlay(const KnowableState& st
   for (unsigned i=0; i<choices.Size(); ++i) {
     Card card = it.next();
     printf("%3s em=%4.2f pr=%4.2f | ", NameOf(card), empiricalExpectedScore[i], predictedExpectedScore[i]);
-    for (int j=0; j<5; j++)
+    for (int j=0; j<3; j++)
       printf(" em=%2.1f", empiricalMoonProb[i][j]);
     printf("\n");
   }
@@ -70,6 +70,6 @@ void DnnMonteCarloAnnotator::OnGameStateBeforePlay(const GameState& state)
 }
 
 void DnnMonteCarloAnnotator::OnWriteData(const KnowableState& state, PossibilityAnalyzer* analyzer, const float empiricalExpectedScore[13]
-                          , const float empiricalMoonProb[13][5], const float winsTrickProb[13])
+                          , const float empiricalMoonProb[13][3], const float winsTrickProb[13])
 {
 }

--- a/lib/DnnMonteCarloAnnotator.h
+++ b/lib/DnnMonteCarloAnnotator.h
@@ -13,12 +13,12 @@ public:
   DnnMonteCarloAnnotator(const tensorflow::SavedModelBundle& model);
 
   virtual void On_DnnMonteCarlo_choosePlay(const KnowableState& state, PossibilityAnalyzer* analyzer
-                                 , const float expectedScore[13], const float moonProb[13][5]);
+                                 , const float expectedScore[13], const float moonProb[13][3]);
 
   virtual void OnGameStateBeforePlay(const GameState& state);
 
   virtual void OnWriteData(const KnowableState& state, PossibilityAnalyzer* analyzer, const float expectedScore[13]
-  , const float moonProb[13][5], const float winsTrickProb[13]);
+  , const float moonProb[13][3], const float winsTrickProb[13]);
 
 private:
   const tensorflow::SavedModelBundle& mModel;

--- a/lib/GameOutcome.cpp
+++ b/lib/GameOutcome.cpp
@@ -92,22 +92,24 @@ void GameOutcome::updateMoonStats(unsigned currentPlayer, int iChoice, int moonC
 
 float GameOutcome::boringScore(unsigned currentPlayer) const {
   assert(mScores[currentPlayer] <= 26u);
-  float score = mScores[currentPlayer] - 6.5;
-  assert(score >= -6.5);
-  assert(score <= 19.5);
+  float score = mScores[currentPlayer];
+  assert(score >= 0.0);
+  assert(score <= 26.0);
   return score;
 }
 
-float GameOutcome::modifiedScore(unsigned currentPlayer) const
+float GameOutcome::standardScore(unsigned currentPlayer) const
 {
-  float score = boringScore(currentPlayer);
-  if (mShotTheMoon) {
-    unsigned myScore = mScores[currentPlayer];
-    if (myScore == kExpectedTotal) {
-      score -= 39.0;
-    } else {
-      score += 13.0;
-    }
+  assert(mScores[currentPlayer] <= 26u);
+  if (!mShotTheMoon)
+  {
+    return boringScore(currentPlayer) - 6.5;
   }
-  return score;
+  else
+  {
+    if (mScores[currentPlayer] == 26u)
+      return -19.5;
+    else
+      return 6.5;
+  }
 }

--- a/lib/GameOutcome.cpp
+++ b/lib/GameOutcome.cpp
@@ -7,10 +7,8 @@
 
 const unsigned kExpectedTotal = 26u;
 
-GameOutcome::GameOutcome(int stopTheMoonPenalty)
-: mStopTheMoonPenalty(stopTheMoonPenalty)
-, mShooter(-1)
-, mStopper(-1)
+GameOutcome::GameOutcome()
+: mShooter(-1)
 {
 
 }
@@ -73,18 +71,8 @@ void GameOutcome::Set(unsigned pointTricks[4], unsigned score[4])
   // We can tell that one player shot the moon when the other three players took no points
   mShotTheMoon = withZeroTricks==3;
 
-  // Detecting that one player stopped another is harder, as there is multiple conditions we have to check.
-  mStoppedTheMoon = withZeroTricks==2
-                && withOneTrick==1 && withMultipleTricks==1 && pointsInOneTricks<=4;
-
-  // It's not possible that in the same game that both someone shot the moon and someone stopped a player from shooting.
-  assert(!mStoppedTheMoon || !mShotTheMoon);
-
   if (mShotTheMoon) {
     mShooter = firstWith(mScores, kExpectedTotal);
-  } else if (mStoppedTheMoon) {
-    mStopper = firstWith(mPointTricks, 1);
-    mShooter = firstWithMany(mPointTricks);
   }
 }
 
@@ -98,13 +86,6 @@ void GameOutcome::updateMoonStats(unsigned currentPlayer, int iChoice, int moonC
     } else {
       assert(mShooter!=-1 && mShooter!=currentPlayer);
       ++moonCounts[iChoice][kOtherShotTheMoon];
-    }
-  } else if (mStoppedTheMoon) {
-    unsigned myPointTricks = mPointTricks[currentPlayer];
-    if (myPointTricks == 1) {
-      ++moonCounts[iChoice][kCurrentStoppedTheMoon];
-    } else if (myPointTricks > 1) {
-      ++moonCounts[iChoice][kOtherStoppedTheMoon];
     }
   }
 }
@@ -126,13 +107,6 @@ float GameOutcome::modifiedScore(unsigned currentPlayer) const
       score -= 39.0;
     } else {
       score += 13.0;
-    }
-  }
-  else if (mStoppedTheMoon && mPointTricks[currentPlayer]!=0) {
-    if (mPointTricks[currentPlayer] == 1) {
-      score -= mStopTheMoonPenalty;
-    } else {
-      score += mStopTheMoonPenalty;
     }
   }
   return score;

--- a/lib/GameOutcome.h
+++ b/lib/GameOutcome.h
@@ -16,15 +16,13 @@
 enum MoonCountKey {
   kCurrentShotTheMoon = 0,
   kOtherShotTheMoon = 1,
-  kCurrentStoppedTheMoon = 2,
-  kOtherStoppedTheMoon = 3,
-  kNumMoonCountKeys = 4
+  kNumMoonCountKeys = 2
 };
 
 class GameOutcome
 {
 public:
-  GameOutcome(int stopTheMoonPenalty=6);
+  GameOutcome();
 
   GameOutcome(const GameOutcome& other);
 
@@ -49,14 +47,10 @@ public:
     // The full score range is -19.5 to 24.5.
 
   const bool shotTheMoon() const { return mShotTheMoon; }
-  const bool stoppedTheMoon() const { return mStoppedTheMoon; }
 
 private:
-  const int mStopTheMoonPenalty;
   unsigned mScores[4];
   unsigned mPointTricks[4];
   bool mShotTheMoon;
-  bool mStoppedTheMoon;
   int mShooter;
-  int mStopper;
 };

--- a/lib/GameOutcome.h
+++ b/lib/GameOutcome.h
@@ -34,17 +34,11 @@ public:
 
   float boringScore(unsigned currentPlayer) const;
     // Return the score for the boring game of hearts, i.e. one without shooting the moon.
-    // This score is in the range of -6.5 to +19.5.
+    // This score is in the range of 0.0 to 26.0.
 
   float standardScore(unsigned currentPlayer) const;
-    // Return the standard score, taking into account shooting the moon.
+    // Return the standard score, taking into account shooting the moon, but with zero mean.
     // This score is in the range of -19.5 to 18.5.
-
-  float modifiedScore(unsigned currentPlayer) const;
-    // Return a score that is modified to favor players who play a smart defensive game that prevents shooting the moon.
-    // This score is also zero mean as the above, but has a higher range, up to 18.5+stopTheMoonPenalty,
-    // and goes below -6.5 for the player who stopped the moon, to as low as as -5.5-stopTheMoonPenalty.
-    // The full score range is -19.5 to 24.5.
 
   const bool shotTheMoon() const { return mShotTheMoon; }
 

--- a/lib/HeartsState.h
+++ b/lib/HeartsState.h
@@ -39,6 +39,16 @@ public:
     // false if the card is not in trick suit or is less than the high card in trick so far.
     // A true means the card is not ruled out from taking trick, but does not guarantee it will.
 
+  bool WillCardTakeTrick(Card card) const;
+    // True if this legal play card is guaranteed to take the current trick.
+    // False if card is not in trick suit, or is less than unplayed cards in the suit.
+
+  bool IsCardOnTable(Card card) const;
+    // True if card is currently face up on table in current trick
+
+  unsigned PointsOnTable() const;
+    // Return the number of points for cards currently face up on the table
+
   // Trick relative
   unsigned PlayerLeadingTrick() const { return mLead; }
   unsigned PlayInTrick() const { return mNextPlay % 4; }

--- a/lib/KnowableState.h
+++ b/lib/KnowableState.h
@@ -54,7 +54,7 @@ public:
 
   void PrepareHands(CardHands& hands) const;
 
-  void AsProbabilities(float prob[52][4]) const;
+  void AsProbabilities(float prob[kCardsPerDeck][kNumPlayers]) const;
     // Fill the prob array with approximate probabilities of player holding the card.
     // For the current player, we assign 1.0 probability to each card in hand.
     // For the other 3 players, the probabilities are just assigned uniformly across the players who are

--- a/lib/KnowableState.h
+++ b/lib/KnowableState.h
@@ -15,6 +15,7 @@ namespace tensorflow {
 };
 
 // Doc for Eigen::Tensor is https://bitbucket.org/eigen/eigen/src/de7544f256bdeb135f7d016e2ddf344a9e0406eb/unsupported/Eigen/CXX11/src/Tensor/README.md
+typedef Eigen::Tensor<float, 1, Eigen::RowMajor>  FloatVector;
 typedef Eigen::Tensor<float, 2, Eigen::RowMajor>  FloatMatrix;
 
 // One prediction input is a FloatMatrix with 52 rows and 10 columns

--- a/lib/KnowableState.h
+++ b/lib/KnowableState.h
@@ -17,6 +17,10 @@ namespace tensorflow {
 class KnowableState : public HeartsState
 {
 public:
+  static const int kNumFeaturesPerCard = 10;
+  static const int kNumFeatures = kNumFeaturesPerCard * kCardsPerDeck;
+
+public:
   KnowableState(const GameState& other);
 
   GameState HypotheticalState() const;
@@ -44,39 +48,6 @@ public:
   Card TransformAndPredict(const tensorflow::SavedModelBundle& model, float playExpectedValue[13]) const;
 
   Card ParsePrediction(const std::vector<tensorflow::Tensor>& outputs, float playExpectedValue[13]) const;
-
-  struct ExtraFeatures {
-    float mPlayProgress;
-    float mTricksProgess;
-    float mInTrickProgress;
-    float mGuaranteedSluff[4];
-    float mGuaranteedTake[4];
-    float mStength[4];
-    float mForcedTake[4];
-    float mForcedAllow[4];
-    float mVulnerability[4];
-
-    float mTotalGuaranteedSluff;
-    float mTotalGuaranteedTake;
-    float mTotalStrength;
-    float mTotalForcedTake;
-    float mTotalForcedAllow;
-    float mTotalVulnerability;
-
-    void Print(FILE* out);
-    void AppendTo(Eigen::TensorMap<Eigen::Tensor<float, 2, 1, long>, 16, Eigen::MakePointer> m, int &index);
-  };
-
-  void ComputeExtraFeatures(ExtraFeatures& extra) const;
-
-public:
-  static const int kNumPlayers = 4;
-  static const int kNumFeaturesPerCard = kNumPlayers + 3;
-  static const int kMoonFlagsLen = 4;
-  static const int kPlaysPerTrick = 4;
-  static const int kPointsExtraFeatures = kPlaysPerTrick + 1 + kMoonFlagsLen;
-  static const int kNumExtraFeatures = sizeof(ExtraFeatures) / sizeof(float);
-  static const int kNumFeatures = kNumFeaturesPerCard * kCardsPerDeck + kPointsExtraFeatures + kNumExtraFeatures;
 
 private:
   KnowableState();  // unimplemented

--- a/lib/KnowableState.h
+++ b/lib/KnowableState.h
@@ -14,6 +14,26 @@ namespace tensorflow {
   struct SavedModelBundle;
 };
 
+// Doc for Eigen::Tensor is https://bitbucket.org/eigen/eigen/src/de7544f256bdeb135f7d016e2ddf344a9e0406eb/unsupported/Eigen/CXX11/src/Tensor/README.md
+typedef Eigen::Tensor<float, 2, Eigen::RowMajor>  FloatMatrix;
+
+// One prediction input is a FloatMatrix with 52 rows and 10 columns
+// FloatMatrix predictionInput(52, 10)
+
+enum FeatureColumns
+{
+  eLegalPlay,
+  eCardProbPlayer0,
+  eCardProbPlayer1,
+  eCardProbPlayer2,
+  eCardProbPlayer3,
+  eCardPoints,
+  eCardOnTable,
+  eCardIsHighCardInTrick,
+  ePlayerNotRuledOutForMoon,
+  eOtherNotRuledOutForMoon,
+};
+
 class KnowableState : public HeartsState
 {
 public:
@@ -42,6 +62,9 @@ public:
   tensorflow::Tensor Transform() const;
     // Transform this state into the the `mainData` tensor input for predict.
 
+  FloatMatrix AsFloatMatrix() const;
+    // Returns an Eigen3 maxtrix with kCardsPerDeck rows and kNumFeaturesPerCard columns
+
   Card Predict(const tensorflow::SavedModelBundle& model, const tensorflow::Tensor& mainData, float playExpectedValue[13]) const;
     // Run tensorflow prediction given the model and tensor input.
 
@@ -54,7 +77,10 @@ private:
 
   void VerifyKnowableState() const;
 
-private:
+  void FillRuledOutForMoonColumnsWhenNoPointsTaken(const CardHand& choices, FloatMatrix& result) const;
+  void FillRuledOutForMoonColumnsWhenOtherPlayerRuledOut(const CardHand& choices, FloatMatrix& result) const;
+  void FillRuledOutForMoonColumnsWhenCurrentPlayerRuledOut(const CardHand& choices, FloatMatrix& result) const;
 
+private:
   CardHand mHand;
 };

--- a/lib/MonteCarlo.cpp
+++ b/lib/MonteCarlo.cpp
@@ -233,7 +233,7 @@ Card MonteCarlo::Stats::ComputeProbabilities(const CardHand& choices
       assert(score <=  18.5 + kEpsilon);
     }
 
-    expectedScore[i] = score - offset;
+    expectedScore[i] = (score - offset) / 26.0;
     if (bestScore > score) {
       bestScore = score;
       bestChoice = i;

--- a/lib/MonteCarlo.cpp
+++ b/lib/MonteCarlo.cpp
@@ -145,7 +145,7 @@ Card MonteCarlo::choosePlay(const KnowableState& knowableState, const RandomGene
     totalStats = RunParallelTasks(knowableState, rng, analyzer, choices);
   }
 
-  float moonProb[13][5];
+  float moonProb[13][3];
   float winsTrickProb[13];
   float expectedScore[13];
 
@@ -184,27 +184,24 @@ void MonteCarlo::Stats::UntrackTrickWinner(GameState& next) {
   next.TrackTrickWinner(0);
 }
 
-const float kStopTheMoonPenalty = 6.0;
 const float kScoreTypeOffsets[kNumScoreTypes][kNumMoonCountKeys] = {
-  { 0.0, 0.0, 0.0, 0.0 },                                     // kBoringScore
-  { -39.0, 13.0, 0, 0 },                                      // kStandardScore
-  { -39.0, 13.0, -kStopTheMoonPenalty, kStopTheMoonPenalty }, // kModifiedScore
+  { 0.0, 0.0 },                                     // kBoringScore
+  { -39.0, 13.0 },                                      // kStandardScore
+  { -39.0, 13.0 }, // kModifiedScore
 };
 
 Card MonteCarlo::Stats::ComputeProbabilities(const CardHand& choices
-                        , float moonProb[13][5]
+                        , float moonProb[13][kNumMoonCountKeys+1]
                         , float winsTrickProb[13]
                         , float expectedScore[13]
                         , ScoreType scoreType) const
 {
   const float kScale = 1.0 / mTotalAlternates;
   for (unsigned i=0; i<choices.Size(); ++i) {
-    int notMoonCount = mTotalAlternates - (moonCounts[i][0] + moonCounts[i][1] + moonCounts[i][2] + moonCounts[i][3]);
+    int notMoonCount = mTotalAlternates - (moonCounts[i][0] + moonCounts[i][1]);
     moonProb[i][kCurrentShotTheMoon] = moonCounts[i][kCurrentShotTheMoon] * kScale;
     moonProb[i][kOtherShotTheMoon] = moonCounts[i][kOtherShotTheMoon] * kScale;
-    moonProb[i][kCurrentStoppedTheMoon] = moonCounts[i][kCurrentStoppedTheMoon] * kScale;
-    moonProb[i][kOtherStoppedTheMoon] = moonCounts[i][kOtherStoppedTheMoon] * kScale;
-    moonProb[i][4] = notMoonCount * kScale;
+    moonProb[i][2] = notMoonCount * kScale;
 
     winsTrickProb[i] = trickWins[i] * kScale;
   }

--- a/lib/MonteCarlo.h
+++ b/lib/MonteCarlo.h
@@ -2,10 +2,10 @@
 
 #include "lib/Strategy.h"
 #include "lib/Annotator.h"
+#include "lib/GameOutcome.h"
 #include "dlib/threads.h"
 
 class KnowableState;
-class GameOutcome;
 
 enum ScoreType {
   // We support three different scoring variants.
@@ -76,7 +76,7 @@ private:
     void FinishedOneAlternate() { ++mTotalAlternates; }
 
     Card ComputeProbabilities(const CardHand& choices
-                            , float moonProb[13][5]
+                            , float moonProb[13][kNumMoonCountKeys+1]
                             , float winsTrickProb[13]
                             , float expectedScore[13]
                             , ScoreType scoreType) const;
@@ -92,13 +92,11 @@ private:
     // We use it to estimate the probability that if we play this card it will take the trick.
     unsigned trickWins[13];
 
-    int moonCounts[13][4];
+    int moonCounts[13][kNumMoonCountKeys];
        // Counts across all of the rollouts of when one of four significant events related to shooting the moon occured
        // There is a fifth event, which is the common case where points are split without anyone coming close to shooting moon
        // mc[i][0] is I shot the moon,
        // mc[i][1] is other shot the moon
-       // mc[i][2] is I stopped other from shooting the moon
-       // mc[i][3] is other stopped me from shooting the moon
   };
 
   void PlayOneAlternate(const KnowableState& knowableState

--- a/lib/MonteCarlo.h
+++ b/lib/MonteCarlo.h
@@ -19,15 +19,8 @@ enum ScoreType {
     // The standard score, taking into account shooting the moon.
     // This score is in the range of -19.5 to 18.5.
 
-  kModifiedScore = 2,
-    // A score that is modified to favor players who play a smart defensive game that prevents shooting the moon.
-    // This score is also zero mean as the above, but has a higher range, up to 18.5+kStopTheMoonPenalty,
-    // and goes below -6.5 for the player who stopped the moon, to as low as as -5.5-kStopTheMoonPenalty.
-    // kStopTheMoonPenalty is currently hard coded to 6.0.
-    // The full score range is -19.5 to 24.5.
-
-  kNumScoreTypes = 3,
-    // This is not a score type, but instead is the constant 3, the number of different score types.
+  kNumScoreTypes = 2,
+    // This is not a score type, but instead is the number of different score types.
 };
 
 class MonteCarlo : public Strategy
@@ -79,7 +72,8 @@ private:
                             , float moonProb[13][kNumMoonCountKeys+1]
                             , float winsTrickProb[13]
                             , float expectedScore[13]
-                            , ScoreType scoreType) const;
+                            , ScoreType scoreType
+                            , float offset=0.0) const;
   private:
     unsigned mNumLegalPlays;
 

--- a/lib/NumpyWriter.h
+++ b/lib/NumpyWriter.h
@@ -1,0 +1,173 @@
+// lib/NumpyWriter.h
+
+#pragma once
+
+#include <unsupported/Eigen/CXX11/Tensor>
+#include <vector>
+#include <stdexcept>
+#include <fcntl.h>
+#include <system_error>
+#include <unistd.h>
+
+// For now, we only support writing arrays of single precision float
+
+template <int rank>
+class NumpyWriter
+{
+public:
+  NumpyWriter(const std::string& path, const std::vector<int>& shape);
+    // Opens a file at path with read/write access, and writes header
+    // Only tensors with the given shape may be written.
+
+  ~NumpyWriter();
+    // Updates the header for the total number of tensors written, then closes the file
+
+  void Append(const Eigen::Tensor<float, rank, Eigen::RowMajor>& tensor);
+    // Appends the tensor to the file
+    // tensor must have the shape specified in ctor
+    // Tensors must use RowMajor layout to be compatible with numpy files
+
+private:
+
+  enum Constants {
+    kMagicStrLen = 8,
+    TOTAL_HEADER = 6 * 16,  // must be a multiple of 16.
+      // This TOTAL_HEADER only has an excess of about 25 bytes from a minimal header
+      // (rank 2, both dimension single decimal digits, less than 10 tensors in the file).
+      // But 25 bytes is way more than we're likely to ever need. Suppose we have rank 3
+      // 4x13x10 and 10 million tensors. In that case we use about 12 more bytes.
+    kSizeofShort = sizeof(unsigned short),
+    kDictOffset = kMagicStrLen + kSizeofShort,
+    HEADER_LEN = TOTAL_HEADER - kDictOffset,
+    kSpace = 0x20,
+  };
+
+  void Write(const void* buffer, int numBytes) const;
+
+  void PaddedHeader(char header[HEADER_LEN]) const;
+    // Fills the entire header with spaces except for last character which will be newline
+
+  void WriteHeader() const;
+
+  std::string ShapeFor() const;
+
+  void UpdateFileSize() const;
+
+private:
+  const int mFile;
+    // The unix file descriptor
+
+  const std::vector<int> mShape;
+    // The shape of all tensors written to this file
+
+  off_t mLenOffset;
+    // The offset from the beginning of the file where the number of tensor rows must be written
+
+  unsigned mNumTensors;
+    // The number of tensors that have been written to the file
+
+};
+
+template <int rank>
+NumpyWriter<rank>::NumpyWriter(const std::string& path, const std::vector<int>& shape)
+: mFile(::open(path.c_str(), O_CREAT|O_WRONLY|O_TRUNC, 0644))
+, mShape(shape)
+, mLenOffset(0)
+, mNumTensors(0)
+{
+  if (mFile == -1) {
+    throw std::system_error(std::error_code(), "Error opening numpy file for read/write access" );
+  }
+  if (mShape.size() != rank) {
+    throw std::invalid_argument("Shape not consistent with rank");
+  }
+  WriteHeader();
+}
+
+template <int rank>
+NumpyWriter<rank>::~NumpyWriter()
+{
+  UpdateFileSize();
+  ::close(mFile);
+}
+
+template <int rank>
+void NumpyWriter<rank>::Write(const void* buffer, int numBytes) const
+{
+  ssize_t actual = ::write(mFile, buffer, numBytes);
+  if (actual != numBytes) {
+    throw std::system_error(std::error_code(), "Failed to write expected number of bytes");
+  }
+}
+
+template <int rank>
+void NumpyWriter<rank>::PaddedHeader(char fill[HEADER_LEN]) const
+{
+  memset(fill, kSpace, HEADER_LEN);
+  assert(fill[0] == kSpace);
+  assert(fill[1] == kSpace);
+  assert(fill[HEADER_LEN-1] == kSpace);
+  fill[HEADER_LEN-1] = '\n';
+}
+
+
+template <int rank>
+void NumpyWriter<rank>::WriteHeader() const {
+  Write("\x93NUMPY\x01\x00", kMagicStrLen);
+
+  // Note: we're assuming this code will only run on little-endian machines.
+  // Should be a safe assumption because it is highly unlikely it will ever run on anything other than x86.
+  const unsigned short kHeaderLen = HEADER_LEN;
+  Write(&kHeaderLen, kSizeofShort);
+
+  char header[HEADER_LEN];
+  PaddedHeader(header);
+  Write(header, HEADER_LEN);
+}
+
+template <int rank>
+std::string NumpyWriter<rank>::ShapeFor() const
+{
+  const char* kComma = ", ";
+  std::stringstream ss;
+  ss << "(" << mNumTensors;
+  for (auto it=mShape.begin(); it!=mShape.end(); ++it) {
+    ss << kComma << *it;
+  }
+  ss << ")";
+  return ss.str();
+}
+
+template <int rank>
+void NumpyWriter<rank>::UpdateFileSize() const
+{
+  // The <f4 is the data type for single precision float. We hard code it here.
+  // To support other types, we'd need to derive the correct numpy dtype string from the C++ type.
+  const char* dictFormat = "{'descr': '<f4', 'fortran_order': False, 'shape': %s}";
+
+  char dict[HEADER_LEN];
+  PaddedHeader(dict);
+  int actual = snprintf(dict, HEADER_LEN-1, dictFormat, ShapeFor().c_str());
+  assert(dict[actual] == 0);
+  dict[actual] = kSpace;
+  assert(dict[HEADER_LEN-2] == kSpace);
+  assert(dict[HEADER_LEN-1] == '\n');
+
+  lseek(mFile, kDictOffset, SEEK_SET);
+  Write(dict, HEADER_LEN);
+}
+
+template <int rank>
+void NumpyWriter<rank>::Append(const Eigen::Tensor<float, rank, Eigen::RowMajor>& tensor)
+{
+  const auto& d = tensor.dimensions();
+  assert(d.size() == rank);
+  for (int i=0; i<rank; i++) {
+    assert(d[i] == mShape[i]);
+  }
+  const float* raw = tensor.data();
+  ssize_t kBytes = sizeof(float)*tensor.size();
+  assert(kBytes > 4);
+  Write(raw, kBytes);
+  ++mNumTensors;
+}

--- a/lib/WriteDataAnnotator.cpp
+++ b/lib/WriteDataAnnotator.cpp
@@ -156,8 +156,8 @@ void WriteDataAnnotator::OnWriteData(const KnowableState& state, PossibilityAnal
     // We want to make it easy on our models to learn to predict appoximate number of points that can be taken.
     // We'll use the moonProb prediction to come the corrected score.
     const float kEpsilon = 0.001;  // a little fudge factor for inexact floating point.
-    assert(expectedScore[i] >= -6.5 - kEpsilon);
-    assert(expectedScore[i] <= 19.5 + kEpsilon);
+    assert(expectedScore[i] >=  0.0 - kEpsilon);
+    assert(expectedScore[i] <= 26.0 + kEpsilon);
 
     fprintf(out, "%3s  %5.4f %5.4f | %s %s %s\n", NameOf(card), expectedScore[i], winsTrickProb[i]
                , FixedPointToString(f[0]).c_str(), FixedPointToString(f[1]).c_str(), FixedPointToString(f[2]).c_str());

--- a/lib/WriteDataAnnotator.cpp
+++ b/lib/WriteDataAnnotator.cpp
@@ -164,10 +164,5 @@ void WriteDataAnnotator::OnWriteData(const KnowableState& state, PossibilityAnal
              );
   }
 
-  fprintf(out, "--\n");
-  KnowableState::ExtraFeatures extra;
-  state.ComputeExtraFeatures(extra);
-  extra.Print(out);
-
   fprintf(out, "----\n");
 }

--- a/lib/WriteDataAnnotator.cpp
+++ b/lib/WriteDataAnnotator.cpp
@@ -49,7 +49,7 @@ WriteDataAnnotator::WriteDataAnnotator(bool validateMode)
 
 void WriteDataAnnotator::On_DnnMonteCarlo_choosePlay(const KnowableState& state
                                   , PossibilityAnalyzer* analyzer
-                                  , const float expectedScore[13], const float moonProb[13][5])
+                                  , const float expectedScore[13], const float moonProb[13][3])
 {
 }
 
@@ -73,7 +73,7 @@ std::string FixedPointToString(int x)
 }
 
 void WriteDataAnnotator::OnWriteData(const KnowableState& state, PossibilityAnalyzer* analyzer, const float expectedScore[13]
-                          , const float moonProb[13][5], const float winsTrickProb[13])
+                          , const float moonProb[13][3], const float winsTrickProb[13])
 {
   FILE* out = mFiles[state.PlayNumber()];
   fprintf(out, "%s\n", asHexString(state.dealIndex()).c_str());
@@ -116,9 +116,10 @@ void WriteDataAnnotator::OnWriteData(const KnowableState& state, PossibilityAnal
   for (unsigned i=0; i<choices.Size(); ++i) {
     Card card = it.next();
 
-    int f[5];
+    const int kNumMoonProbClasses = 3;
+    int f[kNumMoonProbClasses];
     int sum = 0;
-    for (int j=0; j<5; j++) {
+    for (int j=0; j<kNumMoonProbClasses; j++) {
       int scaled = int(moonProb[i][j] * kScale + 0.5);
       sum += scaled;
       f[j] = scaled;
@@ -128,7 +129,7 @@ void WriteDataAnnotator::OnWriteData(const KnowableState& state, PossibilityAnal
       const int kHalf = kScale/2;
       int delta = kScale - sum; // should be 1 nearly all the time
       sum += delta;
-      for (int j=0; j<5; j++) {
+      for (int j=0; j<kNumMoonProbClasses; j++) {
         if (f[j]>0 && f[j]<kHalf) {
           f[j] += delta;
           break;
@@ -140,7 +141,7 @@ void WriteDataAnnotator::OnWriteData(const KnowableState& state, PossibilityAnal
       // We will reduce the largest value
       int imax = 0;
       int max = f[imax];
-      for (int j=1; j<5; j++) {
+      for (int j=1; j<kNumMoonProbClasses; j++) {
         if (max < f[j]) {
           max = f[j];
           imax = j;
@@ -158,10 +159,8 @@ void WriteDataAnnotator::OnWriteData(const KnowableState& state, PossibilityAnal
     assert(expectedScore[i] >= -6.5 - kEpsilon);
     assert(expectedScore[i] <= 19.5 + kEpsilon);
 
-    fprintf(out, "%3s  %5.4f %5.4f | %s %s %s %s %s\n", NameOf(card), expectedScore[i], winsTrickProb[i]
-               , FixedPointToString(f[0]).c_str(), FixedPointToString(f[1]).c_str(), FixedPointToString(f[2]).c_str()
-               , FixedPointToString(f[3]).c_str(), FixedPointToString(f[4]).c_str()
-             );
+    fprintf(out, "%3s  %5.4f %5.4f | %s %s %s\n", NameOf(card), expectedScore[i], winsTrickProb[i]
+               , FixedPointToString(f[0]).c_str(), FixedPointToString(f[1]).c_str(), FixedPointToString(f[2]).c_str());
   }
 
   fprintf(out, "----\n");

--- a/lib/WriteDataAnnotator.h
+++ b/lib/WriteDataAnnotator.h
@@ -10,12 +10,12 @@ public:
   WriteDataAnnotator(bool validateMode=false);
 
   virtual void On_DnnMonteCarlo_choosePlay(const KnowableState& state, PossibilityAnalyzer* analyzer
-                                 , const float expectedScore[13], const float moonProb[13][5]);
+                                 , const float expectedScore[13], const float moonProb[13][3]);
 
   virtual void OnGameStateBeforePlay(const GameState& state);
 
   virtual void OnWriteData(const KnowableState& state, PossibilityAnalyzer* analyzer, const float expectedScore[13]
-  , const float moonProb[13][5], const float winsTrickProb[13]);
+  , const float moonProb[13][3], const float winsTrickProb[13]);
 
 private:
   const std::string mHash;

--- a/lib/WriteTrainingDataSets.cpp
+++ b/lib/WriteTrainingDataSets.cpp
@@ -1,0 +1,68 @@
+// lib/WriteTrainingDataSets.cpp
+
+#include "lib/WriteTrainingDataSets.h"
+#include "lib/GameState.h"
+#include "lib/KnowableState.h"
+#include "lib/PossibilityAnalyzer.h"
+#include "lib/random.h"
+
+#include <assert.h>
+#include <sys/stat.h>
+
+WriteTrainingDataSets::~WriteTrainingDataSets()
+{
+}
+
+const std::string dataDirPath("data/");
+
+WriteTrainingDataSets::WriteTrainingDataSets()
+: mHash(asHexString(RandomGenerator::Random128()))
+, mMainDataWriter(dataDirPath+mHash+"-main.npy", std::vector<int>({52, 10}))
+, mExpectedScoreWriter(dataDirPath+mHash+"-score.npy", std::vector<int>({52}))
+, mMoonProbWriter(dataDirPath+mHash+"-moon.npy", std::vector<int>({52, 3}))
+, mWinTrickProbWriter(dataDirPath+mHash+"-trick.npy", std::vector<int>({52}))
+{
+}
+
+void WriteTrainingDataSets::On_DnnMonteCarlo_choosePlay(const KnowableState& state
+                                  , PossibilityAnalyzer* analyzer
+                                  , const float expectedScore[13], const float moonProb[13][3])
+{
+}
+
+void WriteTrainingDataSets::OnGameStateBeforePlay(const GameState& state)
+{
+}
+
+void WriteTrainingDataSets::OnWriteData(const KnowableState& state, PossibilityAnalyzer* analyzer, const float expectedScore[13]
+                          , const float moonProb[13][3], const float winsTrickProb[13])
+{
+  FloatMatrix mainData = state.AsFloatMatrix();
+  mMainDataWriter.Append(mainData);
+
+  const CardHand choices = state.LegalPlays();
+
+  FloatVector scoreData(kCardsPerDeck);
+  scoreData.setZero();
+  FloatVector trickData(kCardsPerDeck);
+  trickData.setZero();
+  FloatMatrix moonData(kCardsPerDeck, 3);
+  moonData.setZero();
+
+  CardHand::iterator it(choices);
+  int i = 0;
+  while (!it.done()) {
+    Card card = it.next();
+    scoreData(card) = expectedScore[i];
+    trickData(card) = winsTrickProb[i];
+
+    for (int j=0; j<3; ++j) {
+      moonData(card, j) = moonProb[i][j];
+    }
+    ++i;
+  }
+
+  mExpectedScoreWriter.Append(scoreData);
+  mMoonProbWriter.Append(moonData);
+  mWinTrickProbWriter.Append(trickData);
+}

--- a/lib/WriteTrainingDataSets.h
+++ b/lib/WriteTrainingDataSets.h
@@ -1,0 +1,26 @@
+// lib/WriteTrainingDataSets.h
+#pragma once
+
+#include "lib/Annotator.h"
+#include "lib/NumpyWriter.h"
+
+class WriteTrainingDataSets : public Annotator {
+public:
+  ~WriteTrainingDataSets();
+  WriteTrainingDataSets();
+
+  virtual void On_DnnMonteCarlo_choosePlay(const KnowableState& state, PossibilityAnalyzer* analyzer
+                                 , const float expectedScore[13], const float moonProb[13][3]);
+
+  virtual void OnGameStateBeforePlay(const GameState& state);
+
+  virtual void OnWriteData(const KnowableState& state, PossibilityAnalyzer* analyzer, const float expectedScore[13]
+  , const float moonProb[13][3], const float winsTrickProb[13]);
+
+private:
+  const std::string mHash;
+  NumpyWriter<2> mMainDataWriter;
+  NumpyWriter<1> mExpectedScoreWriter;
+  NumpyWriter<2> mMoonProbWriter;
+  NumpyWriter<1> mWinTrickProbWriter;
+};

--- a/memmap.py
+++ b/memmap.py
@@ -14,7 +14,7 @@ def npBatchShape(shape):
     return (-1,) + shape
 
 def save_to_memmap(data, path, p=None):
-    """ Save a numpay array `data` as a memmap file to the given `path`. Optionally permute the data first."""
+    """ Save a numpy array `data` as a memmap file to the given `path`. Optionally permute the data first."""
     print('Writing:', path)
     fp = np.memmap(path, dtype='float32', mode='w+', shape=data.shape)
     if p is not None:
@@ -25,9 +25,9 @@ def save_to_memmap(data, path, p=None):
 
 def as_numpy(group):
     mainData = group['main']
-    scoresData = group['scores']
-    winTrickProbs = group['winTrick']
-    moonProbData = group['moonProb']
+    scoresData = group['score']
+    winTrickProbs = group['trick']
+    moonProbData = group['moon']
 
     nsamples = len(mainData)
     assert len(scoresData) == nsamples
@@ -54,8 +54,8 @@ def save_group(group, datasetDir):
     p = np.random.permutation(nsamples)
 
     save_to_memmap(mainData, f'{datasetDir}/main_data.np.mmap', p)
-    save_to_memmap(scoresData, f'{datasetDir}/scores_data.np.mmap', p)
-    save_to_memmap(winTrickProbs, f'{datasetDir}/win_trick_data.np.mmap', p)
+    save_to_memmap(scoresData, f'{datasetDir}/score_data.np.mmap', p)
+    save_to_memmap(winTrickProbs, f'{datasetDir}/trick_data.np.mmap', p)
     save_to_memmap(moonProbData, f'{datasetDir}/moon_data.np.mmap', p)
 
 def load_memmap(filePath, rowShape):
@@ -65,8 +65,8 @@ def load_memmap(filePath, rowShape):
 
 def load_dataset(dirPath):
     mainData = load_memmap(f'{dirPath}/main_data.np.mmap', MAIN_INPUT_SHAPE)
-    scoresData = load_memmap(f'{dirPath}/scores_data.np.mmap', SCORES_SHAPE)
-    winTrickProbs = load_memmap(f'{dirPath}/win_trick_data.np.mmap', WIN_TRICK_PROBS_SHAPE)
+    scoresData = load_memmap(f'{dirPath}/score_data.np.mmap', SCORES_SHAPE)
+    winTrickProbs = load_memmap(f'{dirPath}/trick_data.np.mmap', WIN_TRICK_PROBS_SHAPE)
     moonProbData = load_memmap(f'{dirPath}/moon_data.np.mmap', MOONPROBS_SHAPE)
 
     nsamples = len(mainData)

--- a/merge_datasets.py
+++ b/merge_datasets.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+# Read one or more memmap datasets (as created by transform.py)
+# and merge them into a larger dataset.
+
+import glob
+import memmap
+import numpy as np
+import os
+import re
+import sys
+
+def extract_hash(path):
+    m = re.match(r'data/([\da-f]+)-main.npy', path)
+    assert m is not None
+    return m[1]
+
+def merge_kind(group, purpose, kind, hashes):
+    group[kind] = []
+    for hash in hashes:
+        a = np.load('data/{}-{}.npy'.format(hash, kind))
+        group[kind].append(a)
+    group[kind] = np.concatenate(group[kind])
+    print(kind, group[kind].shape)
+
+def merge_dataset(purpose, hashes):
+    group = {}
+    for kind in ['main', 'moon', 'score', 'trick']:
+        merge_kind(group, purpose, kind, hashes)
+
+    N = len(group['main'])
+    assert N == len(group['moon'])
+    assert N == len(group['score'])
+    assert N == len(group['trick'])
+    memmap.save_group(group, purpose + '/xx.m')
+
+if __name__ == '__main__':
+
+    main_files = glob.glob('data/*-main.npy')
+    hashes = [extract_hash(path) for path in main_files]
+
+    num_datasets = len(hashes)
+    N = num_datasets // 2
+
+    training = hashes[:N]
+    validation = hashes[N:]
+
+    print('Training:', training)
+    print('Validation:', validation)
+
+    merge_dataset('training', training)
+    merge_dataset('validation', validation)

--- a/model.py
+++ b/model.py
@@ -37,7 +37,7 @@ def one_conv_layer(input, ranks=2, stride=1, activation=swish, name='', isTraini
     assert (input_height-kernel_height) % stride == 0
     output_height = ((input_height-kernel_height) // stride) + 1
 
-    SCALE = 0.9
+    SCALE = 0.75
     # With SCALE=1.0, we compute a number of output filters/features that will approximate the number of input features
     # We typically will want to gradually reduce the number of features in each layer, so use a SCALE a little less than 1.0
     filters = int(round(SCALE * float(input_height)*float(input_features)/float(output_height)))

--- a/model.py
+++ b/model.py
@@ -102,7 +102,6 @@ def model_fn(features, labels, mode, params={}):
 
     hidden_width = params['hidden_width']
     hidden_depth = params['hidden_depth']
-    redundancy = params['redundancy']
     num_batches = params['num_batches']
     activation = activation_fn(params['activation'])
 

--- a/model.py
+++ b/model.py
@@ -113,7 +113,8 @@ def model_fn(features, labels, mode, params={}):
 
     conv_layers = convolution_layers(mainData, activation, isTraining)
 
-    last_common_layer = hidden_layers(conv_layers, hidden_depth, hidden_width, activation)
+    layer = hidden_layers(conv_layers, hidden_depth, hidden_width, activation)
+    last_common_layer = tf.layers.dense(layer, hidden_width)
 
     outputs_dict = {}
 

--- a/model.py
+++ b/model.py
@@ -15,10 +15,7 @@ def extract_distribution(mainData):
     which is 4 suits by 13 ranks by 6 features. We will apply a conv2d to each of the four planes of 13x6 arrays.
     """
     with tf.variable_scope('extract_distribution'):
-        distribution = mainData[:, 0:INPUT_FEATURES*CARDS_IN_DECK]
-        distribution = tf.reshape(distribution, [-1, INPUT_FEATURES, CARDS_IN_DECK])
-        distribution = tf.transpose(distribution, perm=[0,2,1])
-        distribution = tf.reshape(distribution, [-1, NUM_SUITS, NUM_RANKS, INPUT_FEATURES], name='distribution')
+        distribution = tf.reshape(mainData, [-1, NUM_SUITS, NUM_RANKS, INPUT_FEATURES], name='distribution')
     return distribution
 
 def hidden_layers(input, depth, width, activation):
@@ -110,30 +107,13 @@ def model_fn(features, labels, mode, params={}):
     activation = activation_fn(params['activation'])
 
     mainData = features[MAIN_DATA]
-    conv_layers = convolution_layers(mainData, activation, isTraining)
 
     with tf.variable_scope('legal_plays'):
-        legalPlays = mainData[:, CARDS_IN_DECK*4:CARDS_IN_DECK*5]  # extract the 5th feature column
+        legalPlays = mainData[:, :, 0]  # extract the first feature column
 
-    # print('conv_layers shape:', conv_layers.shape)
-    # print('mainData shape:', mainData.shape)
+    conv_layers = convolution_layers(mainData, activation, isTraining)
 
-    extra_features = mainData[:, INPUT_FEATURES*CARDS_IN_DECK:]
-
-    with tf.variable_scope('combined'):
-        if redundancy == 0:
-            combined = tf.concat([conv_layers, extra_features ], axis=-1, name='combined')
-        else:
-            first_suit = 4-redundancy
-            redundant = extract_distribution(mainData)
-            assert redundant.shape.as_list() == [None, NUM_SUITS, NUM_RANKS, INPUT_FEATURES]
-            redundant = redundant[:, first_suit:, :, :]
-            assert redundant.shape.as_list() == [None, redundancy, NUM_RANKS, INPUT_FEATURES]
-            redundant = tf.layers.flatten(redundant, name='redundant')
-            combined = tf.concat([conv_layers, redundant, extra_features], axis=-1, name='combined')
-
-    combined = hidden_layers(combined, hidden_depth, hidden_width, activation)
-    last_common_layer = tf.layers.dense(combined, hidden_width)
+    last_common_layer = hidden_layers(conv_layers, hidden_depth, hidden_width, activation)
 
     outputs_dict = {}
 

--- a/model.py
+++ b/model.py
@@ -168,6 +168,7 @@ def model_fn(features, labels, mode, params={}):
     if SCORE:
       with tf.variable_scope('expected_score_loss'):
           y_expected_score = labels[EXPECTED_SCORE]
+          y_expected_score = tf.divide(y_expected_score, 26.0)  # TODO: Remove next time we regenerate data
           expected_score_diff = tf.subtract(y_expected_score, expectedScoreLogits)
           expected_score_diff2 = tf.square(expected_score_diff)
           expected_score_squared_sum = tf.reduce_sum(expected_score_diff2)

--- a/numpywriter.cpp
+++ b/numpywriter.cpp
@@ -1,0 +1,17 @@
+// numpywriter.cpp
+
+#include "lib/NumpyWriter.h"
+#include <unsupported/Eigen/CXX11/Tensor>
+
+int main(int argc, char** argv)
+{
+  Eigen::Tensor<float, 2, Eigen::RowMajor> data1(2, 3);
+  data1.setValues({{0., 1., 2.}, {3., 4., 5.}});
+  Eigen::Tensor<float, 2, Eigen::RowMajor> data2(2, 3);
+  data2.setValues({{6., 7., 8.}, {9., 10., 11.}});
+
+  std::vector<int> shape({2, 3});
+  NumpyWriter<2> w("test.npy", shape);
+  w.Append(data1);
+  w.Append(data2);
+}

--- a/testnpwriter.py
+++ b/testnpwriter.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 
 import numpy as np
+import sys
 
-a = np.load('test.npy')
-print(a)
+file_path = 'test.npy' if len(sys.argv)==1 else sys.argv[1]
+
+np.set_printoptions(linewidth=300)
+a = np.load(file_path)
+
+
+print(np.array_repr(a, max_line_width=1000, suppress_small=True))

--- a/testnpwriter.py
+++ b/testnpwriter.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import numpy as np
+
+a = np.load('test.npy')
+print(a)

--- a/tournament.cpp
+++ b/tournament.cpp
@@ -212,9 +212,9 @@ struct Scores {
     for (int j=0; j<4; ++j) {
       StrategyPtr player = players[j];
       int playerIndex = player == gChampion ? 0 : 1;
-      mPlayer[playerIndex] += outcome.modifiedScore(j);
-      mPosition[j] += outcome.modifiedScore(j);
-      mCross[playerIndex][j] += outcome.modifiedScore(j);
+      mPlayer[playerIndex] += outcome.standardScore(j);
+      mPosition[j] += outcome.standardScore(j);
+      mCross[playerIndex][j] += outcome.standardScore(j);
     }
   }
 
@@ -249,7 +249,7 @@ void runOneGame(uint128_t dealIndex, StrategyPtr players[4], Scores& scores, boo
     for (int i=0; i<4; ++i) {
       StrategyPtr player = players[i];
       int playerIndex = player == gChampion ? 0 : 1;
-      printf("%s=%5.1f ", name[playerIndex], outcome.modifiedScore(i));
+      printf("%s=%5.1f ", name[playerIndex], outcome.standardScore(i));
     }
     if (moon)
       printf("  Shot the moon!\n");

--- a/tournament.cpp
+++ b/tournament.cpp
@@ -240,7 +240,6 @@ void runOneGame(uint128_t dealIndex, StrategyPtr players[4], Scores& scores, boo
   GameState state(deck);
   GameOutcome outcome = state.PlayGame(players, rng);
   moon = outcome.shotTheMoon();
-  bool stopped = outcome.stoppedTheMoon();
 
   const char* name[2] = {"c", "o"};
 
@@ -254,8 +253,6 @@ void runOneGame(uint128_t dealIndex, StrategyPtr players[4], Scores& scores, boo
     }
     if (moon)
       printf("  Shot the moon!\n");
-    else if (stopped)
-      printf("  Moon stopped!\n");
     else
       printf("\n");
   }

--- a/train.py
+++ b/train.py
@@ -41,8 +41,8 @@ def load_memmap(filePath, rowShape):
 
 def load_memmaps(dirPath):
     mainData = load_memmap(dirPath + '/main_data.np.mmap', MAIN_INPUT_SHAPE)
-    scoresData = load_memmap(dirPath + '/scores_data.np.mmap', SCORES_SHAPE)
-    winTrickProbs = load_memmap(dirPath + '/win_trick_data.np.mmap', WIN_TRICK_PROBS_SHAPE)
+    scoresData = load_memmap(dirPath + '/score_data.np.mmap', SCORES_SHAPE)
+    winTrickProbs = load_memmap(dirPath + '/trick_data.np.mmap', WIN_TRICK_PROBS_SHAPE)
     moonProbData = load_memmap(dirPath + '/moon_data.np.mmap', MOONPROBS_SHAPE)
 
     nsamples = len(mainData)

--- a/train.py
+++ b/train.py
@@ -195,8 +195,8 @@ if __name__ == '__main__':
     print('num_batches, threshold:', num_batches, threshold)
 
     evals = {}
-    for hidden_width in [128, 140]:
-        for hidden_depth in [1, 2]:
+    for hidden_depth in [1, 2]:
+        for hidden_width in range(150, 226, 25):
             for activation in ['relu']:
                 params = {
                     'hidden_depth': hidden_depth,

--- a/train.py
+++ b/train.py
@@ -123,7 +123,7 @@ def train_with_params(train_memmaps, eval_memmaps, params, serving_input_receive
     num_batches = params['num_batches']
     threshold = params['threshold']
 
-    model_dir_path = '{}/d{}w{}r{}_{}'.format(ROOT_MODEL_DIR, hidden_depth, hidden_width, redundancy, activation)
+    model_dir_path = '{}/d{}w{}_{}'.format(ROOT_MODEL_DIR, hidden_depth, hidden_width, activation)
     os.makedirs(model_dir_path, exist_ok=True)
 
     params['model_dir_path'] = model_dir_path
@@ -195,20 +195,18 @@ if __name__ == '__main__':
     print('num_batches, threshold:', num_batches, threshold)
 
     evals = {}
-    for hidden_width in range(180,210,1):
-        for hidden_depth in [1]:
+    for hidden_width in [128, 140]:
+        for hidden_depth in [1, 2]:
             for activation in ['relu']:
-                for redundancy in [0]:
-                    params = {
-                        'hidden_depth': hidden_depth,
-                        'hidden_width': hidden_width,
-                        'activation': activation,
-                        'redundancy': redundancy,
-                        'num_batches': num_batches,
-                        'threshold': threshold,
-                    }
-                    results = train_with_params(train_memmaps, eval_memmaps, params, serving_input_receiver_fn=serving_input_receiver_fn)
-                    evals['d{}w{}r{}_{}'.format(hidden_depth, hidden_width, redundancy, activation)] = results
+                params = {
+                    'hidden_depth': hidden_depth,
+                    'hidden_width': hidden_width,
+                    'activation': activation,
+                    'num_batches': num_batches,
+                    'threshold': threshold,
+                }
+                results = train_with_params(train_memmaps, eval_memmaps, params, serving_input_receiver_fn=serving_input_receiver_fn)
+                evals['d{}w{}_{}'.format(hidden_depth, hidden_width, activation)] = results
 
     for k, v in evals.items():
         print(v, k, file=sys.stderr)


### PR DESCRIPTION
This commit adds and revises the feature columns so that there are now ten feature columns total, and removes all of the "extra" features. To make it possible to only use CNN feature columns, the model now predicts the expected additional points that the player will take over the rest of the game, rather than their expected total points. I also reverted the "moon probabilities" feature to use just 3 classes instead of 5, i.e. I dropped the stop-moon calculations.